### PR TITLE
more endpoints

### DIFF
--- a/abilities.go
+++ b/abilities.go
@@ -1,0 +1,37 @@
+package pokeapi
+
+type Ability struct {
+	ID                int                   `json:"id"`
+	Name              string                `json:"name"`
+	IsMainSeries      bool                  `json:"is_main_series"`
+	Generation        NamedAPIResource      `json:"generation"`
+	Names             []Name                `json:"names"`
+	EffectEntries     []VerboseEffect       `json:"effect_entries"`
+	EffectChanges     []AbilityEffectChange `json:"effect_changes"`
+	FlavorTextEntries []AbilityFlavorText   `json:"flavor_text_entries"`
+	Pokemon           []AbilityPokemon      `json:"pokemon"`
+}
+
+type AbilityEffectChange struct {
+	EffectEntries []VerboseEffect  `json:"effect_entries"`
+	VersionGroup  NamedAPIResource `json:"version_group"`
+}
+
+type AbilityFlavorText struct {
+	FlavorText   string           `json:"flavor_text"`
+	Language     NamedAPIResource `json:"language"`
+	VersionGroup NamedAPIResource `json:"version_group"`
+}
+
+type AbilityPokemon struct {
+	IsHidden bool             `json:"is_hidden"`
+	Slot     int              `json:"slot"`
+	Pokemon  NamedAPIResource `json:"pokemon"`
+}
+
+func GetAbility(id string) (Ability, error) {
+	var ability Ability
+	pokeapiUrl := client.urlBuilder(endpoints["ability"], id)
+	err := client.Get(pokeapiUrl, &ability)
+	return ability, err
+}

--- a/client.go
+++ b/client.go
@@ -55,42 +55,7 @@ func (c *RESTClient) Get(pokeapiUrl string, pokeObj any) error {
 
 }
 
-func GetSpecies(id string) (PokemonSpecies, error) {
-	var species PokemonSpecies
-	pokeapiUrl := client.urlBuilder(endpoints["pokemon-species"], id)
-	err := client.Get(pokeapiUrl, &species)
-	return species, err
-}
-
-func GetPokemon(id string) (Pokemon, error) {
-	var pokemon Pokemon
-	pokeapiUrl := client.urlBuilder(endpoints["pokemon"], id)
-	err := client.Get(pokeapiUrl, &pokemon)
-	return pokemon, err
-}
-
-func GetEvolutions(id string) (EvolutionChain, error) {
-	var evolution EvolutionChain
-	pokeapiUrl := client.urlBuilder(endpoints["evolution-chain"], id)
-	err := client.Get(pokeapiUrl, &evolution)
-	return evolution, err
-}
-
-func GetGeneration(id string) (Generation, error) {
-	var generation Generation
-	pokeapiUrl := client.urlBuilder(endpoints["generation"], id)
-	err := client.Get(pokeapiUrl, &generation)
-	return generation, err
-}
-
-func GetNamedEndpoint(endpoint string) (Named, error) {
-	var named Named
-	pokeapiUrl := client.urlBuilder(endpoints[endpoint], "")
-	err := client.Get(pokeapiUrl, &named)
-	return named, err
-}
-
-// buildClientEndpoint creates a URL for the given endpoint using the current configuration
+// Creates a URL for the given endpoint using the current configuration
 func buildClientEndpoint(env string) (*url.URL, error) {
 	papiurl, err := url.Parse(os.Getenv(env))
 	if err != nil {
@@ -106,13 +71,13 @@ func buildClientEndpoint(env string) (*url.URL, error) {
 	return papiurl, nil
 }
 
+func (c *RESTClient) urlBuilder(endpoint, id string) string {
+	return fmt.Sprintf("%v/%v/%v", client.requestUrl.String(), endpoints[endpoint], id)
+}
+
 func papiEnvEmpty(env string) bool {
 	if env == "" {
 		return true
 	}
 	return false
-}
-
-func (c *RESTClient) urlBuilder(endpoint, id string) string {
-	return fmt.Sprintf("%v/%v/%v", client.requestUrl.String(), endpoints[endpoint], id)
 }

--- a/commonmodels.go
+++ b/commonmodels.go
@@ -1,17 +1,7 @@
 package pokeapi
 
-type Languages struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	Official bool   `json:"official"`
-	ISO639   string `json:"iso639"`
-	ISO3166  string `json:"iso3166"`
-	Names    []Name `json:"names"`
-}
-
-type NamedAPIResource struct {
-	Name string `json:"name"`
-	Url  string `json:"url"`
+type APIResource struct {
+	Url string `json:"url,omitempty"`
 }
 
 type Description struct {
@@ -19,9 +9,33 @@ type Description struct {
 	Language    NamedAPIResource `json:"language,omitempty"`
 }
 
-type VersionGameIndex struct {
-	GameIndex int              `json:"game_index,omitempty"`
-	Version   NamedAPIResource `json:"version,omitempty"`
+type Effect struct {
+	Effect   string           `json:"effect,omitempty"`
+	Language NamedAPIResource `json:"language,omitempty"`
+}
+
+type Encounter struct {
+	MinLevel        int                `json:"min_level,omitempty"`
+	MaxLevel        int                `json:"max_level,omitempty"`
+	ConditionValues []NamedAPIResource `json:"condition_values,omitempty"`
+	Chance          int                `json:"chance,omitempty"`
+	Method          NamedAPIResource   `json:"method,omitempty"`
+}
+
+type FlavorText struct {
+	FlavorText string           `json:"flavor_text,omitempty"`
+	Language   NamedAPIResource `json:"language,omitempty"`
+	Version    NamedAPIResource `json:"version,omitempty"`
+}
+
+type GenerationGameIndex struct {
+	GameIndex  int              `json:"game_index,omitempty"`
+	Generation NamedAPIResource `json:"geneartion,omitempty"`
+}
+
+type MachineVersionDetail struct {
+	Machine      APIResource      `json:"machine,omitempty"`
+	VersionGroup NamedAPIResource `json:"version_group,omitempty"`
 }
 
 type Name struct {
@@ -29,12 +43,30 @@ type Name struct {
 	Language NamedAPIResource `json:"Language,omitempty"`
 }
 
-type APIResource struct {
-	Url string `json:"url,omitempty"`
+type NamedAPIResource struct {
+	Name string `json:"name,omitempty"`
+	Url  string `json:"url,omitempty"`
 }
 
-type FlavorText struct {
-	FlavorText string           `json:"flavor_text,omitempty"`
-	Language   NamedAPIResource `json:"language,omitempty"`
-	Version    NamedAPIResource `json:"version,omitempty"`
+type VerboseEffect struct {
+	Effect      string           `json:"effect,omitempty"`
+	ShortEffect string           `json:"short_effec,omitemptyt"`
+	Language    NamedAPIResource `json:"language,omitempty"`
+}
+
+type VersionEncounterDetail struct {
+	Version          NamedAPIResource `json:"version,omitempty"`
+	MaxChance        int              `json:"max_chance,omitempty"`
+	EncounterDetails []Encounter      `json:"encounter_details,omitempty"`
+}
+
+type VersionGameIndex struct {
+	GameIndex int              `json:"game_index,omitempty"`
+	Version   NamedAPIResource `json:"version,omitempty"`
+}
+
+type VersionGroupFlavorText struct {
+	Text         string           `json:"text,omitempty"`
+	Language     NamedAPIResource `json:"language,omitempty"`
+	VersionGroup NamedAPIResource `json:"version_group,omitempty"`
 }

--- a/constents.go
+++ b/constents.go
@@ -3,7 +3,6 @@ package pokeapi
 import "net/url"
 
 var (
-	// endpoints   = make(map[string]string)
 	papiDefault = url.URL{
 		Scheme: "https",
 		Host:   "pokeapi.co",
@@ -15,7 +14,7 @@ var (
 
 // endpoints map from key:string to value:string. To change the endpoint, change the value.
 //
-// Example:
+// Example, chaging the ability endpoint:
 //
 //	"ability": "ability", change to "ability": "someOtherEndpoint"
 var endpoints = map[string]string{

--- a/evolutionchains.go
+++ b/evolutionchains.go
@@ -1,9 +1,5 @@
 package pokeapi
 
-import (
-	"reflect"
-)
-
 type EvolutionChain struct {
 	ID              int               `json:"id"`
 	BabyTriggerItem *NamedAPIResource `json:"baby_trigger_item,omitempty"`
@@ -37,6 +33,16 @@ type EvolutionDetail struct {
 	TurnUpsideDown        bool              `json:"turn_upside_down,omitempty"`
 }
 
+// Get evolution chain by ID
+//
+//	chain, _ := GetEvolutionChain("80")
+func GetEvolutionChain(id string) (EvolutionChain, error) {
+	var evolution EvolutionChain
+	pokeapiUrl := client.urlBuilder(endpoints["evolution-chain"], id)
+	err := client.Get(pokeapiUrl, &evolution)
+	return evolution, err
+}
+
 // Returns a flat array of the evolution chain for the pokemon
 func (c *ChainLink) Flatten() ([]ChainLink, error) {
 	evolutionList := []ChainLink{}
@@ -57,28 +63,4 @@ func (c *ChainLink) Flatten() ([]ChainLink, error) {
 	}
 	return evolutionList, nil
 
-}
-
-func (e *EvolutionDetail) GetDetails() map[any]any {
-	keyValue := make(map[any]any)
-
-	v := reflect.ValueOf(*e)
-	typeOfS := v.Type()
-	// named := NamedAPIResource{}
-
-	for i := 0; i < v.NumField(); i++ {
-		fieldName := typeOfS.Field(i).Name
-		value := v.Field(i).Interface()
-		fieldType := v.Field(i).Type()
-		if (value != 0) && (value != nil) && (value != "") && (fieldType != reflect.TypeOf(&NamedAPIResource{})) {
-			// fmt.Printf("fieldType: %+v\t", fieldType)
-			// fmt.Printf("fieldName: %s\tValue: %+v\n", fieldName, value)
-
-			keyValue[fieldName] = value
-		} else if (value != 0) && (value != nil) && (value != "") && (fieldType == reflect.TypeOf(&NamedAPIResource{})) {
-			// fmt.Printf("fieldType: %+v\t", fieldType)
-			// fmt.Printf("fieldName: %s\tValue: %+v\n", fieldName, value)
-		}
-	}
-	return keyValue
 }

--- a/generations.go
+++ b/generations.go
@@ -11,3 +11,10 @@ type Generation struct {
 	Types          []NamedAPIResource `json:"types"`
 	VersionGroups  []NamedAPIResource `json:"version_groups"`
 }
+
+func GetGeneration(id string) (Generation, error) {
+	var generation Generation
+	pokeapiUrl := client.urlBuilder(endpoints["generation"], id)
+	err := client.Get(pokeapiUrl, &generation)
+	return generation, err
+}

--- a/language.go
+++ b/language.go
@@ -1,0 +1,17 @@
+package pokeapi
+
+type Language struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Official bool   `json:"official"`
+	ISO639   string `json:"iso639"`
+	ISO3166  string `json:"iso3166"`
+	Names    []Name `json:"names"`
+}
+
+func GetLanguage(id string) (Language, error) {
+	var language Language
+	pokeapiUrl := client.urlBuilder(endpoints["language"], id)
+	err := client.Get(pokeapiUrl, &language)
+	return language, err
+}

--- a/named.go
+++ b/named.go
@@ -6,3 +6,10 @@ type Named struct {
 	Previous string             `json:"previous"`
 	Results  []NamedAPIResource `json:"results"`
 }
+
+func GetNamedEndpoint(endpoint string) (Named, error) {
+	var named Named
+	pokeapiUrl := client.urlBuilder(endpoints[endpoint], "")
+	err := client.Get(pokeapiUrl, &named)
+	return named, err
+}

--- a/pokemon.go
+++ b/pokemon.go
@@ -1,5 +1,6 @@
 package pokeapi
 
+// https://pokeapi.co/docs/v2#pokemon
 type Pokemon struct {
 	ID                     int                `json:"id"`
 	Name                   string             `json:"name"`
@@ -102,4 +103,11 @@ type PokemonSpritesHome struct {
 type PokemonOfficialArtwork struct {
 	FrontDefault string `json:"front_default"`
 	FrontShiny   string `json:"front_shiny"`
+}
+
+func GetPokemon(id string) (Pokemon, error) {
+	var pokemon Pokemon
+	pokeapiUrl := client.urlBuilder(endpoints["pokemon"], id)
+	err := client.Get(pokeapiUrl, &pokemon)
+	return pokemon, err
 }

--- a/pokemonforms.go
+++ b/pokemonforms.go
@@ -23,3 +23,10 @@ type PokemonFormSprites struct {
 	BackDefault  string `json:"back_default"`
 	BackShiny    string `json:"back_shiny"`
 }
+
+func GetPokemonForm(id string) (PokemonForm, error) {
+	var form PokemonForm
+	pokeapiUrl := client.urlBuilder(endpoints["pokemon-form"], id)
+	err := client.Get(pokeapiUrl, &form)
+	return form, err
+}

--- a/pokemonspecies.go
+++ b/pokemonspecies.go
@@ -50,6 +50,13 @@ type PokemonSpeciesVariety struct {
 	Pokemon   NamedAPIResource `json:"pokemon"`
 }
 
+func GetPokemonSpecies(id string) (PokemonSpecies, error) {
+	var species PokemonSpecies
+	pokeapiUrl := client.urlBuilder(endpoints["pokemon-species"], id)
+	err := client.Get(pokeapiUrl, &species)
+	return species, err
+}
+
 // Returns a flat array of all pokemon evolution species related to the current pokemon
 func (s *PokemonSpecies) FlattenEvolutions(chain *ChainLink) ([]PokemonSpecies, error) {
 	evolutionChainPokemon := []PokemonSpecies{}
@@ -59,7 +66,7 @@ func (s *PokemonSpecies) FlattenEvolutions(chain *ChainLink) ([]PokemonSpecies, 
 			return evolutionChainPokemon, nil
 		}
 
-		species, err := GetSpecies(evolution.Species.Name)
+		species, err := GetPokemonSpecies(evolution.Species.Name)
 		if err != nil {
 			return evolutionChainPokemon, err
 		}
@@ -78,9 +85,8 @@ func (s *PokemonSpecies) FlattenEvolutions(chain *ChainLink) ([]PokemonSpecies, 
 }
 
 // Returns the base species evolution from an evolution chain
-func (s *PokemonSpecies) GetBaseSpecies(chain *ChainLink) (PokemonSpecies, error) {
-	baseSpecies, err := GetSpecies(chain.Species.Name)
-	// fmt.Printf("base species Name: %v\n", baseSpecies.Name)
+func (s *PokemonSpecies) GetBasePokemonSpecies(chain *ChainLink) (PokemonSpecies, error) {
+	baseSpecies, err := GetPokemonSpecies(chain.Species.Name)
 	if err != nil {
 		return PokemonSpecies{}, err
 	}


### PR DESCRIPTION
- Some restructuring and renaming to reflect api endpoints
- Moved functions into their respective files, eg. `GetPokemon` is now in `pokemon.go`
- Renamed functions to reflect their output value, eg. `GetSpecies` is now `GetPokemonSpecies`
- Moved `Language` struct into its own file to reflect its endpoint
- New:
  - endpoint for ability: `Ability` / `GetAbility()`
  - get: `GetPokemonForm()`